### PR TITLE
Dunfell task dependency

### DIFF
--- a/classes/adu-swupdate.bbclass
+++ b/classes/adu-swupdate.bbclass
@@ -39,5 +39,5 @@ python do_adu_swuimage() {
 }
 
 deltask do_swuimage
-addtask do_swuimage after do_image_complete
-addtask do_adu_swuimage after do_swuimage
+addtask do_swuimage after do_unpack do_prepare_recipe_sysroot do_image_complete before do_build
+addtask do_adu_swuimage after do_swuimage do_image_complete before do_build


### PR DESCRIPTION
I could reproduce #11, but it directly intersects with some lines edited for some other reasons.

@fboor, can you please tell me some more about it? Only after applying the dependencies as written up here it works - before I receive the following error:

```
NOTE: Fetching uninative binary shim http://downloads.yoctoproject.org/releases/uninative/3.4/x86_64-nativesdk-libc.tar.xz;sha256sum=126f4f7f6f21084ee140dac3eb4c536b963837826b7c38599db0b512c3377ba2 (will check PREMIRRORS first)
Initialising tasks: 100% |##################################################################################################################################################################| Time: 0:00:02
Sstate summary: Wanted 1821 Found 1817 Missed 4 Current 0 (99% match, 0% complete)
NOTE: Executing Tasks
ERROR: core-base-image-1.0-r0 do_swuimage: swupdate cannot find image file: /home/yocto/project/build/tmp/deploy/images/core-rpi-p1/core-base-image.ext4.gz
ERROR: Logfile of failure stored in: /home/yocto/project/build/tmp/work/core_rpi_p1-poky-linux-gnueabi/core-base-image/1.0-r0/temp/log.do_swuimage.2532801
ERROR: Task (/home/yocto/project/build/../meta-custom/recipes-bsp/images/core-base-image.bb:do_swuimage) failed with exit code '1'
NOTE: Tasks Summary: Attempted 4610 tasks of which 4273 didn't need to be rerun and 1 failed.

Summary: 1 task failed:
  /home/yocto/project/build/../meta-custom/recipes-bsp/images/core-base-image.bb:do_swuimage
Summary: There were 5 WARNING messages shown.
Summary: There was 1 ERROR message shown, returning a non-zero exit code.
```

After applying the changes of this PR, it runs through.